### PR TITLE
Troubleshoot binary package extraction issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ```bash
 # 下载发布包
-wget https://github.com/your-org/nfs-cachefs/releases/download/v0.1/nfs-cachefs-v0.1-linux-x86_64.tar.gz
+wget https://raw.githubusercontent.com/dionren/nfs-cachefs/main/nfs-cachefs-v0.1-linux-x86_64.tar.gz
 
 # 解压并安装
 tar -xzf nfs-cachefs-v0.1-linux-x86_64.tar.gz
@@ -156,7 +156,7 @@ graph TD
 
 | 系统 | 架构 | 下载链接 |
 |------|------|----------|
-| Ubuntu 22.04/24.04 | x86_64 | [nfs-cachefs-v0.1-linux-x86_64.tar.gz](https://github.com/your-org/nfs-cachefs/releases/download/v0.1/nfs-cachefs-v0.1-linux-x86_64.tar.gz) |
+| Ubuntu 22.04/24.04 | x86_64 | [nfs-cachefs-v0.1-linux-x86_64.tar.gz](https://raw.githubusercontent.com/dionren/nfs-cachefs/main/nfs-cachefs-v0.1-linux-x86_64.tar.gz) |
 
 ### 系统要求
 

--- a/download_release.sh
+++ b/download_release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 下载 nfs-cachefs 发布版本
+echo "正在下载 nfs-cachefs v0.1..."
+
+# 正确的 GitHub raw 链接
+RELEASE_URL="https://raw.githubusercontent.com/dionren/nfs-cachefs/main/nfs-cachefs-v0.1-linux-x86_64.tar.gz"
+FILENAME="nfs-cachefs-v0.1-linux-x86_64.tar.gz"
+
+# 下载文件
+echo "从 $RELEASE_URL 下载..."
+wget -O "$FILENAME" "$RELEASE_URL"
+
+# 检查下载是否成功
+if [ $? -eq 0 ]; then
+    echo "下载成功！"
+    
+    # 验证文件格式
+    echo "验证文件格式..."
+    if tar -tzf "$FILENAME" > /dev/null 2>&1; then
+        echo "文件格式正确，可以解压"
+        echo "解压文件..."
+        tar -xzf "$FILENAME"
+        echo "解压完成！"
+        echo "文件内容："
+        ls -la
+    else
+        echo "错误：文件不是有效的 tar.gz 格式"
+        echo "文件内容："
+        head -5 "$FILENAME"
+    fi
+else
+    echo "下载失败！"
+fi


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix binary package download by updating README links and adding a helper script to use GitHub raw URLs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous download method using GitHub `blob` URLs resulted in downloading an HTML page instead of the actual `tar.gz` file, causing extraction failures. This PR ensures direct binary download.